### PR TITLE
.gitignore added to libleak; Auto-clean the dependent libwuya on "make clean" 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+!.gitignore
+
+#### Files to be ignored
+# Build products
+*.o
+# Final binaries
+*.elf
+*.so

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,5 @@ libleak.so: libleak.o
 	$(CC) -shared -o $@ $^ $(LDFLAGS) -lwuya -lpthread -ldl -lbacktrace
 
 clean:
+	make -C libwuya clean
 	rm -f libleak.so *.o


### PR DESCRIPTION
Changes:
Simple .gitignore file added to libleak to mask the build products from Git
Auto-clean the dependent libwuya on the libleak' make clean to ensure no stale libwuya build products are used